### PR TITLE
Updated PubSub to align with 0.11.0

### DIFF
--- a/src/CoreApi/PubSubApi.cs
+++ b/src/CoreApi/PubSubApi.cs
@@ -48,7 +48,7 @@ namespace Ipfs.Http
             url.Append("/api/v0/pubsub/pub");
             url.Append("?arg=");
             url.Append(System.Net.WebUtility.UrlEncode(topic));
-            url.Append("&arg=");
+            url.Append("&data=");
             var data = Encoding.ASCII.GetString(System.Net.WebUtility.UrlEncodeToBytes(message, 0, message.Length));
             url.Append(data);
             return ipfs.DoCommandAsync(new Uri(ipfs.ApiUri, url.ToString()), cancel);

--- a/src/IpfsHttpClient.csproj
+++ b/src/IpfsHttpClient.csproj
@@ -1,36 +1,37 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>netstandard14;netstandard2;net45</TargetFrameworks>
-    <AssemblyName>Ipfs.Http.Client</AssemblyName>
-    <RootNamespace>Ipfs.Http</RootNamespace>
-    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-    <DebugType>full</DebugType>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<PropertyGroup>
+		<TargetFrameworks>netstandard2;</TargetFrameworks>
+		<AssemblyName>Ipfs.Http.Client</AssemblyName>
+		<RootNamespace>Ipfs.Http</RootNamespace>
+		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+		<DebugType>full</DebugType>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <!-- developer build is always 0.42 -->
-    <AssemblyVersion>0.42</AssemblyVersion>
-    <Version>0.42</Version>
-    
-    <!-- Nuget specs -->
-    <PackageId>Ipfs.Http.Client</PackageId>
-    <Authors>Richard Schneider</Authors>
-    <Title>IPFS HTTP Client</Title>
-    <Description> Provides .Net client access to the InterPlanetary File System.</Description>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>https://github.com/richardschneider/net-ipfs-http-client/releases</PackageReleaseNotes>
-    <Copyright>© 2015-2019 Richard Schneider</Copyright>
-    <PackageTags>ipfs peer-to-peer distributed file-system</PackageTags>
-    <IncludeSymbols>True</IncludeSymbols>
-    <PackageProjectUrl>https://github.com/richardschneider/net-ipfs-http-client</PackageProjectUrl>
-    <PackageIconUrl>https://raw.githubusercontent.com/richardschneider/net-ipfs-core/master/doc/images/ipfs-cs-logo-64x64.png</PackageIconUrl>
-  </PropertyGroup>
+		<!-- developer build is always 0.42 -->
+		<AssemblyVersion>0.42</AssemblyVersion>
+		<Version>0.42</Version>
 
-  <ItemGroup>
-    <PackageReference Include="Ipfs.Core" Version="0.55.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-	  <PackageReference Include="System.Net.Http" Version="4.3.3" Condition="'$(TargetFramework)' == 'netstandard14'" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" Condition="'$(TargetFramework)' == 'net45'" />
-  </ItemGroup>
- 
+		<!-- Nuget specs -->
+		<PackageId>Ipfs.Http.Client</PackageId>
+		<Authors>Richard Schneider</Authors>
+		<Title>IPFS HTTP Client</Title>
+		<Description> Provides .Net client access to the InterPlanetary File System.</Description>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<PackageReleaseNotes>https://github.com/richardschneider/net-ipfs-http-client/releases</PackageReleaseNotes>
+		<Copyright>© 2015-2019 Richard Schneider</Copyright>
+		<PackageTags>ipfs peer-to-peer distributed file-system</PackageTags>
+		<IncludeSymbols>True</IncludeSymbols>
+		<PackageProjectUrl>https://github.com/richardschneider/net-ipfs-http-client</PackageProjectUrl>
+		<PackageIconUrl>https://raw.githubusercontent.com/richardschneider/net-ipfs-core/master/doc/images/ipfs-cs-logo-64x64.png</PackageIconUrl>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Ipfs.Core" Version="0.55.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+		<PackageReference Include="System.Net.Http" Version="4.3.3" Condition="'$(TargetFramework)' == 'netstandard14'" />
+		<PackageReference Include="System.Net.Http" Version="4.3.3" Condition="'$(TargetFramework)' == 'net45'" />
+		<PackageReference Include="Multiformats.Base" Version="2.0.2"/>
+	</ItemGroup>
+
 </Project>

--- a/src/PublishedMessage.cs
+++ b/src/PublishedMessage.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.IO;
 using System.Text;
 using System.Runtime.Serialization;
+using Multiformats.Base;
 
 namespace Ipfs.Http
 {
@@ -12,7 +13,7 @@ namespace Ipfs.Http
     ///   A published message.
     /// </summary>
     /// <remarks>
-    ///   The <see cref="PubSubApi"/> is used to publish and subsribe to a message.
+    ///   The <see cref="PubSubApi"/> is used to publish and subscribe to a message.
     /// </remarks>
     [DataContract]
     public class PublishedMessage : IPublishedMessage
@@ -27,11 +28,13 @@ namespace Ipfs.Http
         public PublishedMessage(string json)
         {
             var o = JObject.Parse(json);
-            this.Sender = Convert.FromBase64String((string)o["from"]).ToBase58();
-            this.SequenceNumber = Convert.FromBase64String((string)o["seqno"]);
-            this.DataBytes = Convert.FromBase64String((string)o["data"]);
+            
+            this.Sender = (string)o["from"];
+            this.SequenceNumber = Multibase.Decode((string)o["seqno"], out MultibaseEncoding _);
+            this.DataBytes = Multibase.Decode((string)o["data"], out MultibaseEncoding _);
+
             var topics = (JArray) (o["topicIDs"]);
-            this.Topics = topics.Select(t => (string)t);
+            this.Topics = topics.Select(t => Encoding.UTF8.GetString(Multibase.Decode((string)t, out MultibaseEncoding _)));
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This PR updates the PubSub APIs to work with the recent [0.11.0 release](https://github.com/ipfs/go-ipfs/issues/8343).

The biggest change in this PR is the removal of support for .NET Framework 4.5 and .NET Standard 1.4. Pubsub now makes heavy use of [multibase encoding](https://docs.ipfs.io/concepts/glossary/#multibase), which are bare to nonexistent in most of .NET. 

Instead of rolling my own, I used the IPFS recommended [cs-multibase](https://github.com/multiformats/cs-multibase) library, This library is only available on .NET Standard 2.0. For my purposes, this works more than fine. netstandard 1.4 is starting to show its age and .NET Framework supports netstandard2.0 starting in 4.6.1.

This does mean that the rest of the IPFS libraries that use this package will need to be updated.

Updated unit tests coming soon™.